### PR TITLE
Modify wrong config path of online_predictor

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Note: The profiler will delete all kubernetes deployments before it starts to mi
 ## Step 2: Run online predictor
 ```bash
 # Run prediction based on book info call graph
-python3 ./meshinsight/predictor/online_predictor.py -c ./meshinsight/predictor/config/base.yml -p meshinsight/profiles/profile.pkl
+python3 ./meshinsight/predictor/online_predictor.py -c ./meshinsight/predictor/config/example1.yml -p meshinsight/profiles/profile.pkl
 
 usage: online_predictor.py [-h] [-v] [-p PROFILE] -c CONFIG
 

--- a/meshinsight/predictor/online_predictor.py
+++ b/meshinsight/predictor/online_predictor.py
@@ -139,7 +139,7 @@ if __name__ == '__main__':
     else:
         logging.basicConfig(format='%(asctime)s - %(message)s', datefmt='%d-%b-%y %H:%M:%S', level=logging.INFO)
 
-    cfg = get_config(os.path.join(MESHINSIGHT_DIR, "meshinsight/predictor/config/base.yml"))
+    cfg = get_config(os.path.join(MESHINSIGHT_DIR, args.config))
     
     logging.debug("Running CRISP to get the critical paths...")
     # Run CRISP to get the critical path for every trace. returns -> (metrics, critical path)


### PR DESCRIPTION
There is no base.yml, but example1.yml in repo.